### PR TITLE
[countries-en] Official name of North Macedonia

### DIFF
--- a/packages/countries-en/resources/data.csv
+++ b/packages/countries-en/resources/data.csv
@@ -142,7 +142,7 @@ me,382,Podgorica,me,mne,eu,eur,🇲🇪,Montenegro
 mf,590,Marigot,mf,maf,na,eur,🇲🇫,Saint Martin
 mg,261,Antananarivo,mg,mdg,af,mga,🇲🇬,Madagascar
 mh,692,Majuro,mh,mhl,oc,usd,🇲🇭,Marshall Islands
-mk,389,Skopje,mk,mkd,eu,mkd,🇲🇰,Macedonia
+mk,389,Skopje,mk,mkd,eu,mkd,🇲🇰,North Macedonia
 ml,223,Bamako,ml,mli,af,xof,🇲🇱,Mali
 mm,95,Nay Pyi Taw,mm,mmr,as,mmk,🇲🇲,Myanmar
 mn,976,Ulan Bator,mn,mng,as,mnt,🇲🇳,Mongolia


### PR DESCRIPTION
"Macedonia" was renamed to "North Macedonia" in February 2019