### PR TITLE
Change Turkey name to reflect US State Department Usage

### DIFF
--- a/packages/countries-en/resources/data.csv
+++ b/packages/countries-en/resources/data.csv
@@ -223,7 +223,7 @@ tl,670,Dili,tl,tls,oc,usd,🇹🇱,East Timor
 tm,993,Ashgabat,tm,tkm,as,tmt,🇹🇲,Turkmenistan
 tn,216,Tunis,tn,tun,af,tnd,🇹🇳,Tunisia
 to,676,Nuku'alofa,to,ton,oc,top,🇹🇴,Tonga
-tr,90,Ankara,tr,tur,as,try,🇹🇷,Türkiye
+tr,90,Ankara,tr,tur,as,try,🇹🇷,Turkey (Türkiye)
 tt,1868,Port of Spain,tt,tto,na,ttd,🇹🇹,Trinidad and Tobago
 tv,688,Funafuti,tv,tuv,oc,aud,🇹🇻,Tuvalu
 tw,886,Taipei,tw,twn,as,twd,🇹🇼,Taiwan


### PR DESCRIPTION
Recently, a PR was made to change "Turkey" to "Türkiye". While it's true that in May 2022, the Turkish government requested the United Nations and other international organizations to use Türkiye officially in English, I suspect that the vast majority of English speakers are not aware of this. As such, I think that this change is confusing and should instead be amended to mirror the US State Department usage, as seen in the screenshot below.

<img width="838" alt="Screenshot 2024-03-24 at 4 24 29 PM" src="https://github.com/squirephp/squire/assets/125735/980be9a1-3ac4-4942-be5e-e88d7f91693f">
