### PR TITLE
Updated French spelling of Türkiye

### DIFF
--- a/packages/countries-fr/resources/data.csv
+++ b/packages/countries-fr/resources/data.csv
@@ -223,7 +223,7 @@ tl,670,Dili,tl,tls,oc,usd,🇹🇱,Timor oriental
 tm,993,Ashgabat,tm,tkm,as,tmt,🇹🇲,Turkménistan
 tn,216,Tunis,tn,tun,af,tnd,🇹🇳,Tunisie
 to,676,Nuku'alofa,to,ton,oc,top,🇹🇴,Tonga
-tr,90,Ankara,tr,tur,as,try,🇹🇷,Turquie
+tr,90,Ankara,tr,tur,as,try,🇹🇷,Türkiye
 tt,1868,Port of Spain,tt,tto,na,ttd,🇹🇹,Trinité-et-Tobago
 tv,688,Funafuti,tv,tuv,oc,aud,🇹🇻,Tuvalu
 tw,886,Taipei,tw,twn,as,twd,🇹🇼,Taïwan


### PR DESCRIPTION
This PR updates the proper French spelling to Türkiye, per the ISO 3166-1 index. Refer to the [ISO 3166-1 change from 2022-07-11](https://www.iso.org/committee/48750.html?t=wTbxub4XFtb4rZti-DE1Bm_2z32hSb0MZ0WYnVbmLimthZ0lvbR7nXh7_U_u5V5L&view=documents#section-isodocuments-top) and the country code listing from the [ISO Online Browsing Platform](https://www.iso.org/obp/ui/#search) below.

<img width="706" alt="Screenshot 2024-03-25 at 9 42 17 AM" src="https://github.com/squirephp/squire/assets/125735/f2640901-52ae-4640-b25a-55e3dd304e4f">
