### PR TITLE
Fix PHP 8.4 str_getcsv escape deprecation

### DIFF
--- a/packages/model/src/Model.php
+++ b/packages/model/src/Model.php
@@ -135,7 +135,7 @@ abstract class Model extends Eloquent\Model
 
         $data = collect(Repository::fetchData(static::class, $locale));
 
-        $schema = collect(str_getcsv($data->first()));
+        $schema = collect(str_getcsv($data->first(), escape: '\\'));
 
         $data->transform(function (string $line) use ($schema): Collection {
             return $schema->combine(

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -45,6 +45,33 @@ class ModelTest extends TestCase
         }
     }
 
+    public function test_can_migrate_models_without_php_deprecations(): void
+    {
+        Repository::registerSource(Models\Foo::class, App::getLocale(), __DIR__ . '/data/foo-en.csv');
+
+        $deprecations = [];
+        $errorReporting = error_reporting(E_ALL);
+
+        set_error_handler(function (int $severity, string $message) use (&$deprecations): bool {
+            if (($severity === E_DEPRECATED) || ($severity === E_USER_DEPRECATED)) {
+                $deprecations[] = $message;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            Models\Foo::cache([App::getLocale()]);
+        } finally {
+            restore_error_handler();
+            error_reporting($errorReporting);
+        }
+
+        $this->assertSame([], $deprecations);
+    }
+
     public function test_can_translate_models(): void
     {
         Repository::registerSource(Models\Foo::class, 'en', __DIR__ . '/data/foo-en.csv');


### PR DESCRIPTION
## Summary
- Pass an explicit escape argument when parsing CSV headers in Squire model migration
- Add coverage that model cache migration does not emit PHP deprecations

## Tests
- ./vendor/bin/phpunit